### PR TITLE
0.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = obd-socketio
-version = 0.2.2
+version = 0.3.0
 author = Bennett Gunson
 author_email = bengunson@gmail.com
 description = Expose python-OBD through an async socketio server


### PR DESCRIPTION
- OBDio class no longer extends obd.Async so we can create/destroy the vehicle connection without having to create a new server etc